### PR TITLE
Change default JS-folder

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -115,7 +115,7 @@ export default class Config {
                 source: process.env.T3BUILD_SRC || config.source || 'src',
                 packages: process.env.T3BUILD_PACKAGES || config.packages || 'packages',
                 css: process.env.T3BUILD_CSS || config.css || 'Css',
-                js: process.env.T3BUILD_JS || config.js || 'Js',
+                js: process.env.T3BUILD_JS || config.js || 'JavaScript',
                 projectPath: process.env.INIT_CWD || process.cwd(),
                 getSourceDir: function () {
                     return path.resolve(path.join(this.projectPath, this.source))


### PR DESCRIPTION
To be inline with TYPO3-defaults, the default JS-folder should be renamed to "JavaScript". This should be reflected in the documentation as soon as https://github.com/mxsteini/t3-build/pull/2 had been implemented